### PR TITLE
Much smoother morphing

### DIFF
--- a/lib/sampled_path_data.dart
+++ b/lib/sampled_path_data.dart
@@ -8,11 +8,15 @@ class SampledPathData {
   var points2;
   var endIndices;
   var shiftedPoints;
+  bool points1IsClosed;
+  bool points2IsClosed;
 
   SampledPathData() {
     points1 = List<Offset>();
     points2 = List<Offset>();
     shiftedPoints = List<Offset>();
     endIndices = List<int>();
+    points1IsClosed = false;
+    points2IsClosed = false;
   }
 }


### PR DESCRIPTION
Currently, morphing transition only looks 'smooth' when the starting (and ending) point of both paths are relatively close to eachother.
- The current code is morphing between points based on their indices, which is suboptimal

Simple heuristics were added, where the morphing pairs are shifted based on their sum of squared distances.
This way, the animation looks much smoother:

- [Before](https://drive.google.com/file/d/1bgRVBe1G1xnj4mG9GEXEzLeHAsl8mkjj/view?usp=sharing)
- [After](https://drive.google.com/file/d/1UKdx1gLnZeUb-hnaO5iO_0CueMdI9B8M/view?usp=sharing)